### PR TITLE
Problem: We need to enable LSEED to run as a Kubernetes pod/service

### DIFF
--- a/lseed.go
+++ b/lseed.go
@@ -26,7 +26,8 @@ import (
 )
 
 var (
-	listenAddr = flag.String("listen", "0.0.0.0:53", "Listen address for incoming requests.")
+	listenAddrUDP = flag.String("listenUDP", "0.0.0.0:53", "UDP listen address for incoming requests.")
+	listenAddrTCP = flag.String("listenTCP", "0.0.0.0:53", "TCP listen address for incoming requests.")
 
 	bitcoinNodeHost  = flag.String("btc-lnd-node", "", "The host:port of the backing btc lnd node")
 	litecoinNodeHost = flag.String("ltc-lnd-node", "", "The host:port of the backing ltc lnd node")
@@ -143,6 +144,8 @@ func poller(lnd lnrpc.LightningClient, nview *seed.NetworkView) {
 
 			if _, err := nview.AddNode(node); err != nil {
 				log.Debugf("Unable to add node: %v", err)
+			} else {
+				log.Debugf("Adding node: %v", node.Addresses)
 			}
 		}
 	}
@@ -160,8 +163,10 @@ func configure() {
 	flag.Parse()
 	if *debug {
 		log.SetLevel(log.DebugLevel)
+		log.Infof("Logging on level Debug")
 	} else {
 		log.SetLevel(log.InfoLevel)
+		log.Infof("Logging on level Info")
 	}
 }
 
@@ -245,7 +250,7 @@ func main() {
 
 	rootIP := net.ParseIP(*authoritativeIP)
 	dnsServer := seed.NewDnsServer(
-		netViewMap, *listenAddr, *rootDomain, rootIP,
+		netViewMap, *listenAddrUDP, *listenAddrTCP, *rootDomain, rootIP,
 	)
 
 	dnsServer.Serve()

--- a/seed/dns.go
+++ b/seed/dns.go
@@ -99,8 +99,6 @@ func (ds *DnsServer) locateChainView(subdomain string) *ChainView {
 
 	subdomain = strings.TrimSpace(subdomain)
 	segments := strings.SplitAfter(subdomain, ".")
-	log.Debug("seg: ", segments)
-	log.Debug("seg: ", len(segments))
 
 	switch {
 
@@ -130,10 +128,6 @@ func (ds *DnsServer) handleAAAAQuery(request *dns.Msg, response *dns.Msg,
 
 	log.Debugf("Handling AAAA query")
 	chainView, ok := ds.chainViews[subDomain]
-	if !ok {
-		log.Errorf("no chain view found for %v", subDomain)
-		return
-	}
 
 	nodes := chainView.NetView.RandomSample(3, 25)
 	for _, n := range nodes {

--- a/seed/network.go
+++ b/seed/network.go
@@ -108,7 +108,8 @@ func (nv *NetworkView) RandomSample(query NodeType, count int) []Node {
 		}
 	}
 
-	fmt.Println("Num reachable nodes: %v", len(nv.reachableNodes))
+	// fmt.Println("Num reachable nodes: %v", len(nv.reachableNodes))
+	log.Infof("Num reachable nodes: %v", len(nv.reachableNodes))
 
 	return result
 }
@@ -271,15 +272,15 @@ func (nv *NetworkView) reachabilityPruner() {
 		// addresses are reachable.
 		case newNode := <-nv.freshNodes:
 			go func() {
-				log.Infof("waiting to grab sema")
+				// log.Infof("waiting to grab sema")
 				<-searchSema
 
 				defer func() {
 					searchSema <- struct{}{}
-					log.Infof("sema returned")
+					// log.Infof("sema returned")
 				}()
 
-				log.Infof("got sema")
+				// log.Infof("got sema")
 				extractReachableAddrs(newNode, false)
 			}()
 

--- a/seed/network.go
+++ b/seed/network.go
@@ -280,7 +280,6 @@ func (nv *NetworkView) reachabilityPruner() {
 					// log.Infof("sema returned")
 				}()
 
-				// log.Infof("got sema")
 				extractReachableAddrs(newNode, false)
 			}()
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/168889/148956696-675ce50a-a46e-40c7-a0c4-0e0543ff6c54.png)

# Problem
LSEED uses port 53 (DNS) to provide joining LND nodes with a list of
existing nodes on the Lightning network. Unfortunately services on port
53 are a bit difficult to provide behind the regular Kubernetes LB or
ingress controller. In particular the fact that LSEED answers queries
on both the UDP and TCP protocol makes it difficult to run in a
Kubernetes environment.

# Solution
To solve the issues describe above this PR provides the following
code changes:

- [x] enhanced logging for events that add new nodes to the LSEED node list
- [x] a Dockerfile to create a containerized version of LSEED
- [x] new parameters with separate listener addresses for UDP and TCP
- [x] a separate listener for UDP and TCP requests utilizing these new
  parameters
- [x] a couple of typo fixes to the Debugf statements in lseed and
  tests