### PR TITLE
lseed: add support for testnet4 and signet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# --- Build stage ---
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /build
+
+# Copy source and Makefile.
+COPY . .
+
+# Install build tools.
+RUN apk add --no-cache git make
+
+# Build using Makefile (install places binary in /go/bin).
+RUN make install
+
+# --- Final stage ---
+FROM gcr.io/distroless/static-debian11
+
+# Add TLS certs for HTTPS/gRPC connections.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy compiled binary.
+COPY --from=builder /go/bin/lseed /lseed
+
+# Run.
+ENTRYPOINT ["/lseed"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,46 @@
+PKG := github.com/lightninglabs/lseed
+BINARY := lseed
+BUILD_DIR := build
+
+GOBUILD := go build -v
+GOINSTALL := go install -v
+GOTEST := go test -v
+GOMOD := go mod
+
+COMMIT := $(shell git describe --always --dirty --abbrev=40)
+COMMIT_HASH := $(shell git rev-parse HEAD)
+GOVERSION := $(shell go version | awk '{print $$3}')
+
+LDFLAGS := -ldflags "-X '$(PKG)/version.Commit=$(COMMIT)' -X '$(PKG)/version.CommitHash=$(COMMIT_HASH)' -X '$(PKG)/version.GoVersion=$(GOVERSION)'"
+
+# Default target.
+all: build
+
+## Build lseed binary into ./build.
+build:
+	@echo "Building $(BINARY)..."
+	$(GOBUILD) -o $(BUILD_DIR)/$(BINARY) $(LDFLAGS) ./lseed.go
+
+## Install binary to $GOBIN.
+install:
+	@echo "📦 Installing $(BINARY) to $$GOBIN..."
+	$(GOINSTALL) $(LDFLAGS) ./lseed.go
+
+## Clean build artifacts.
+clean:
+	rm -rf $(BUILD_DIR)
+
+## Run tests.
+test:
+	$(GOTEST) ./...
+
+## Run go mod tidy.
+mod-tidy:
+	@echo "Tidying Go modules..."
+	$(GOMOD) tidy
+
+## Lint source.
+lint:
+	golangci-lint run
+
+.PHONY: all build install clean test mod-tidy lint

--- a/lseed.go
+++ b/lseed.go
@@ -41,6 +41,14 @@ var (
 	litecoinMacPath = flag.String("ltc-mac-path", "", "The path to the macaroon for the ltc lnd node")
 	testMacPath     = flag.String("test-mac-path", "", "The path to the macaroon for the test lnd node")
 
+	signetNodeHost = flag.String("signet-lnd-node", "", "The host:port of the backing btc signet lnd node")
+	signetTLSPath  = flag.String("signet-tls-path", "", "The path to the TLS cert for the signet lnd node")
+	signetMacPath  = flag.String("signet-mac-path", "", "The path to the macaroon for the signet lnd node")
+
+	testnet4NodeHost = flag.String("testnet4-lnd-node", "", "The host:port of the btc testnet4 lnd node")
+	testnet4TLSPath  = flag.String("testnet4-tls-path", "", "The path to the TLS cert for the testnet4 lnd node")
+	testnet4MacPath  = flag.String("testnet4-mac-path", "", "The path to the macaroon for the testnet4 lnd node")
+
 	rootDomain = flag.String("root-domain", "nodes.lightning.directory", "Root DNS seed domain.")
 
 	authoritativeIP = flag.String("root-ip", "127.0.0.1", "The IP address of the authoritative name server. This is used to create a dummy record which allows clients to access the seed directly over TCP")
@@ -239,6 +247,48 @@ func main() {
 		log.Infof("TBCT chain view active")
 
 		netViewMap["test."] = &seed.ChainView{
+			NetView: nView,
+			Node:    lndNode,
+		}
+	}
+
+	if *signetNodeHost != "" && *signetTLSPath != "" && *signetMacPath != "" {
+		log.Infof("Creating BTC signet chain view")
+
+		lndNode, err := initLightningClient(
+			*signetNodeHost, *signetTLSPath, *signetMacPath,
+		)
+		if err != nil {
+			panic(fmt.Sprintf("unable to connect to signet lnd: %v", err))
+		}
+
+		nView := seed.NewNetworkView("signet")
+		go poller(lndNode, nView)
+
+		log.Infof("Signet chain view active")
+
+		netViewMap["signet."] = &seed.ChainView{
+			NetView: nView,
+			Node:    lndNode,
+		}
+	}
+
+	if *testnet4NodeHost != "" && *testnet4TLSPath != "" && *testnet4MacPath != "" {
+		log.Infof("Creating BTC testnet4 chain view")
+
+		lndNode, err := initLightningClient(
+			*testnet4NodeHost, *testnet4TLSPath, *testnet4MacPath,
+		)
+		if err != nil {
+			panic(fmt.Sprintf("unable to connect to testnet4 lnd: %v", err))
+		}
+
+		nView := seed.NewNetworkView("testnet4")
+		go poller(lndNode, nView)
+
+		log.Infof("Testnet4 chain view active")
+
+		netViewMap["test4."] = &seed.ChainView{
 			NetView: nView,
 			Node:    lndNode,
 		}

--- a/lseed.go
+++ b/lseed.go
@@ -113,7 +113,7 @@ func initLightningClient(nodeHost, tlsCertPath, macPath string) (lnrpc.Lightning
 
 	conn, err := grpc.Dial(nodeHost, opts...)
 	if err != nil {
-		return nil, fmt.Errorf("unable to dial to lnd's gRPC server: ",
+		return nil, fmt.Errorf("unable to dial to lnd's gRPC server: %v",
 			err)
 	}
 

--- a/seed/dns.go
+++ b/seed/dns.go
@@ -128,6 +128,10 @@ func (ds *DnsServer) handleAAAAQuery(request *dns.Msg, response *dns.Msg,
 
 	log.Debugf("Handling AAAA query")
 	chainView, ok := ds.chainViews[subDomain]
+	if !ok {
+		log.Errorf("no chain view found for %v", subDomain)
+		return
+	}
 
 	nodes := chainView.NetView.RandomSample(3, 25)
 	for _, n := range nodes {
@@ -434,4 +438,3 @@ func (ds *DnsServer) Serve() {
 	signal.Notify(quitChan, syscall.SIGINT, syscall.SIGTERM)
 	<-quitChan
 }
-


### PR DESCRIPTION
Allow the lseed daemon to configure and connect to 2 additional backends for `testnet4` and `signet`. Lightning seed information for node bootstrap can be accessed via SRV query against:
- `nodes.lightning.wiki` (mainnet)
- `test.nodes.lightning.wiki` (testnet3)
- `signet.nodes.lightning.wiki` (signet)
- `test4.nodes.lightning.wiki` (testnet4)

Addresses: https://github.com/lightninglabs/lightning-infra/issues/2307